### PR TITLE
Fix object name for DEC tracking of navigation 'pills' widget #325

### DIFF
--- a/Bootstrap/MVC/Scripts/Navigation/pills.js
+++ b/Bootstrap/MVC/Scripts/Navigation/pills.js
@@ -4,7 +4,7 @@
         if (window.DataIntelligenceSubmitScript && target.attr('aria-expanded') === 'false') {
             DataIntelligenceSubmitScript._client.sentenceClient.writeSentence({
                 predicate: "Toggle navigation",
-                object: target.text(),
+                object: target.text().trim(),
                 objectMetadata: [{
                     'K': 'PageTitle',
                     'V': document.title


### PR DESCRIPTION
Needed to remove the trailing empty spaces from html text of list item when getting its name from DOM. It was incorrectly sent to DEC with trailing spaces and new lines.

Reviewers:
- [x] @nistorov
- [x] @vassildinev
