### PR TITLE
Fix for bug: SVG - Image widget with Custom size is not rendered

### DIFF
--- a/Bootstrap/MVC/Views/Image/Image.cshtml
+++ b/Bootstrap/MVC/Views/Image/Image.cshtml
@@ -1,12 +1,19 @@
-@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel
-
-@if (string.IsNullOrEmpty(Model.LinkedContentUrl))
-{
-    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-}
-else
-{
-    <a href="@Model.LinkedContentUrl">
-        <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-    </a>
-}
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
+@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel 
+ 
+@helper ImageTag() {  
+    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" 
+                @Html.GetWidthAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem)
+                @Html.GetHeightAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem) /> 
+} 
+ 
+@if (string.IsNullOrEmpty(Model.LinkedContentUrl)) 
+{ 
+    @ImageTag() 
+} 
+else 
+{ 
+    <a href="@Model.LinkedContentUrl"> 
+        @ImageTag() 
+    </a> 
+} 

--- a/Bootstrap/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
+++ b/Bootstrap/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
@@ -1,6 +1,7 @@
 @model Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery.ImageDetailsViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Web.DataResolving;
 
@@ -18,7 +19,9 @@
 
     <div @Html.InlineEditingFieldAttributes("Description", "LongText")>@Html.Raw(Model.Item.Fields.Description)</div>
 
-    <img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+    <img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                 @Html.GetWidthAttributeIfPresents(Model.Width)
+                 @Html.GetHeightAttributeIfPresents(Model.Height) />
 
     @if (ViewBag.ItemIndex != null)
     {

--- a/Bootstrap/MVC/Views/ImageGallery/List.ImageGallery.cshtml
+++ b/Bootstrap/MVC/Views/ImageGallery/List.ImageGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 
@@ -13,6 +14,8 @@
     @for (int i = 0; i < Model.Items.Count(); i++)
     {
         var item = Model.Items.ElementAt(i);
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
         var itemIndex = (Model.CurrentPage - 1) * ViewBag.ItemsPerPage + i + 1;
 		var detailPageUrl = ViewBag.OpenInSamePage ? HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex) :
             HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix);
@@ -20,7 +23,9 @@
       <a class="text-center"
              href="@detailPageUrl"
        title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
       </a>
       }
   </div>

--- a/Bootstrap/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
+++ b/Bootstrap/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 @using Telerik.Sitefinity.Modules.Pages;
 
@@ -17,10 +18,16 @@
     @{int itemIndex = 0;}
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+
         <a class="text-center image-link"
-            href="@(((ThumbnailViewModel)item).MediaUrl)"
+            href="@(thumbnailViewModel.MediaUrl)"
             title="@item.Fields.AlternativeText">
-            <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)" alt="@item.Fields.AlternativeText" />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" 
+                 data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)" 
+                 alt="@item.Fields.AlternativeText"
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
         </a>
         itemIndex++;
     }

--- a/Bootstrap/MVC/Views/ImageGallery/List.SimpleList.cshtml
+++ b/Bootstrap/MVC/Views/ImageGallery/List.SimpleList.cshtml
@@ -1,6 +1,7 @@
 @model Telerik.Sitefinity.Frontend.Mvc.Models.ContentListViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
@@ -11,8 +12,12 @@
 
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+
     <a class="text-center" title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+      <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' 
+                @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
     </a>
     }
 </div>

--- a/Bootstrap/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
+++ b/Bootstrap/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
@@ -22,6 +22,8 @@
     {
         firstItem = Model.Items.FirstOrDefault();
     }
+
+    ThumbnailViewModel thumbnailViewModel = (ThumbnailViewModel)firstItem;
 }
 
 <div class="sf-Gallery sf-Gallery--strip">
@@ -39,7 +41,9 @@
 	<p class="sf-Gallery-image js-Gallery-image">
 		<a class='js-Gallery-prev sf-Gallery-prev'><span class="glyphicon glyphicon-chevron-left"></span></a>
 		<a class='js-Gallery-next sf-Gallery-next'><span class="glyphicon glyphicon-chevron-right"></span></a>
-		<img src="@(((ThumbnailViewModel)firstItem).MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" />
+        <img src="@(thumbnailViewModel.MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" 
+                  @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                  @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
 
 	</p>
 		}
@@ -66,8 +70,12 @@
 		@{int itemIndex = 0;}
 		@foreach(var item in Model.Items)
 		{
+    var itemViewModel = (ThumbnailViewModel)item;
+    
 			<a class="text-center" title="@item.Fields.Title" data-item="@Html.GetSerializedImage(item)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)">
-				<img src="@(((ThumbnailViewModel)item).ThumbnailUrl)"  alt="@item.Fields.AlternativeText"/>
+        <img src="@(itemViewModel.ThumbnailUrl)" alt="@item.Fields.AlternativeText" 
+                      @Html.GetWidthAttributeIfPresents(itemViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(itemViewModel.Height) />
 			</a>
 			itemIndex++;
 		}

--- a/Minimal/MVC/Views/Image/Image.cshtml
+++ b/Minimal/MVC/Views/Image/Image.cshtml
@@ -1,13 +1,19 @@
-﻿@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel
-
-@if (string.IsNullOrEmpty(Model.LinkedContentUrl))
-{
-    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-}
-else
-{
-    <a href="@Model.LinkedContentUrl">
-        <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-    </a>
-}
-
+﻿@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
+@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel 
+ 
+@helper ImageTag() {  
+    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" 
+                @Html.GetWidthAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem)
+                @Html.GetHeightAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem) /> 
+} 
+ 
+@if (string.IsNullOrEmpty(Model.LinkedContentUrl)) 
+{ 
+    @ImageTag() 
+} 
+else 
+{ 
+    <a href="@Model.LinkedContentUrl"> 
+        @ImageTag() 
+    </a> 
+} 

--- a/Minimal/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
+++ b/Minimal/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
@@ -1,6 +1,7 @@
 ﻿@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery.ImageDetailsViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Web.DataResolving;
 
@@ -18,7 +19,9 @@
 
     <div @Html.InlineEditingFieldAttributes("Description", "LongText")>@Html.Raw(Model.Item.Fields.Description)</div>
 
-    <img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+    <img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                 @Html.GetWidthAttributeIfPresents(Model.Width)
+                 @Html.GetHeightAttributeIfPresents(Model.Height) />
 
     @if (ViewBag.ItemIndex != null)
     {

--- a/Minimal/MVC/Views/ImageGallery/List.ImageGallery.cshtml
+++ b/Minimal/MVC/Views/ImageGallery/List.ImageGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 
@@ -12,6 +13,8 @@
     @for (int i = 0; i < Model.Items.Count(); i++)
     {
         var item = Model.Items.ElementAt(i);
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
         var itemIndex = (Model.CurrentPage - 1) * ViewBag.ItemsPerPage + i + 1;
         var detailPageUrl = ViewBag.OpenInSamePage ? HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex) :
             HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage);
@@ -19,7 +22,9 @@
         <a
        href="@detailPageUrl"
        title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-            <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
         </a>
     }
 

--- a/Minimal/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
+++ b/Minimal/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 @using Telerik.Sitefinity.Modules.Pages;
 
@@ -15,10 +16,16 @@
 <div class="@Model.CssClass">
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
         <a class="image-link"
-            href="@(((ThumbnailViewModel)item).MediaUrl)"
+            href="@(thumbnailViewModel.MediaUrl)"
             title="@item.Fields.AlternativeText">
-            <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix)" alt="@item.Fields.AlternativeText" />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" 
+                 data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix)" 
+                 alt="@item.Fields.AlternativeText"
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
         </a>
     }
 </div>

--- a/Minimal/MVC/Views/ImageGallery/List.SimpleList.cshtml
+++ b/Minimal/MVC/Views/ImageGallery/List.SimpleList.cshtml
@@ -1,6 +1,7 @@
 ﻿@model Telerik.Sitefinity.Frontend.Mvc.Models.ContentListViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
@@ -11,8 +12,12 @@
 
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
     <a title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+      <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' 
+                @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
     </a>
     }
 </div>

--- a/Minimal/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
+++ b/Minimal/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
@@ -22,6 +22,8 @@
     {
         firstItem = Model.Items.FirstOrDefault();
     }
+
+    ThumbnailViewModel thumbnailViewModel = (ThumbnailViewModel)firstItem;
 }
 
 @if (hasItems)
@@ -37,7 +39,9 @@
     <p class="js-Gallery-image">
         <a href="javascript:void(0)" class='js-Gallery-prev'>Prev</a>
         <a href="javascript:void(0)" class='js-Gallery-next'>Next</a>
-        <img src="@(((ThumbnailViewModel)firstItem).MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" />
+        <img src="@(thumbnailViewModel.MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" 
+                  @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                  @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
     </p>
         }
         else
@@ -60,8 +64,12 @@
 <div class="js-Gallery-thumbs">
 @foreach(var item in Model.Items)
 {
+    var itemViewModel = (ThumbnailViewModel)item;
+    
     <a title="@item.Fields.Title" data-item="@Html.GetSerializedImage(item)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix)">
-        <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt="@item.Fields.AlternativeText"/>
+        <img src="@(itemViewModel.ThumbnailUrl)" alt="@item.Fields.AlternativeText" 
+                      @Html.GetWidthAttributeIfPresents(itemViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(itemViewModel.Height) />
     </a>
 }
 </div>

--- a/community-packages/Foundation/MVC/Views/Image/Image.cshtml
+++ b/community-packages/Foundation/MVC/Views/Image/Image.cshtml
@@ -1,12 +1,19 @@
-@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel
-
-@if (string.IsNullOrEmpty(Model.LinkedContentUrl))
-{
-    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-}
-else
-{
-    <a href="@Model.LinkedContentUrl">
-        <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-    </a>
-}
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
+@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel 
+ 
+@helper ImageTag() {  
+    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" 
+                @Html.GetWidthAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem)
+                @Html.GetHeightAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem) /> 
+} 
+ 
+@if (string.IsNullOrEmpty(Model.LinkedContentUrl)) 
+{ 
+    @ImageTag() 
+} 
+else 
+{ 
+    <a href="@Model.LinkedContentUrl"> 
+        @ImageTag() 
+    </a> 
+} 

--- a/community-packages/Foundation/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
+++ b/community-packages/Foundation/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
@@ -1,6 +1,7 @@
 @model Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery.ImageDetailsViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Web.DataResolving;
 
@@ -18,7 +19,9 @@
 
     <p @Html.InlineEditingFieldAttributes("Description", "LongText")>@Html.Raw(Model.Item.Fields.Description)</p>
 
-	<img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+    <img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                 @Html.GetWidthAttributeIfPresents(Model.Width)
+                 @Html.GetHeightAttributeIfPresents(Model.Height) />
 
     @if (ViewBag.ItemIndex != null)
     {

--- a/community-packages/Foundation/MVC/Views/ImageGallery/List.ImageGallery.cshtml
+++ b/community-packages/Foundation/MVC/Views/ImageGallery/List.ImageGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 
@@ -13,6 +14,8 @@
     @for (int i = 0; i < Model.Items.Count(); i++)
     {
         var item = Model.Items.ElementAt(i);
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+
         var itemIndex = (Model.CurrentPage - 1) * ViewBag.ItemsPerPage + i + 1;
 		var detailPageUrl = ViewBag.OpenInSamePage ? HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex) :
             HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix);
@@ -20,7 +23,9 @@
       <a class="pull-left text-center"
              href="@detailPageUrl"
        title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
       </a>
       }
   </div>

--- a/community-packages/Foundation/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
+++ b/community-packages/Foundation/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 @using Telerik.Sitefinity.Modules.Pages;
 
@@ -17,10 +18,16 @@
     @{int itemIndex = 0;}
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+
         <a class="pull-left text-center image-link"
-            href="@(((ThumbnailViewModel)item).MediaUrl)"
+            href="@(thumbnailViewModel.MediaUrl)"
             title="@item.Fields.AlternativeText">
-            <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)" alt="@item.Fields.AlternativeText" />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" 
+                 data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)" 
+                 alt="@item.Fields.AlternativeText"
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
         </a>
         itemIndex++;
     }

--- a/community-packages/Foundation/MVC/Views/ImageGallery/List.SimpleList.cshtml
+++ b/community-packages/Foundation/MVC/Views/ImageGallery/List.SimpleList.cshtml
@@ -1,6 +1,7 @@
 @model Telerik.Sitefinity.Frontend.Mvc.Models.ContentListViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
@@ -12,8 +13,12 @@
 
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
     <a class="pull-left text-center" title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+      <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' 
+                @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
     </a>
     }
 </div>

--- a/community-packages/Foundation/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
+++ b/community-packages/Foundation/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
@@ -22,6 +22,8 @@
     {
         firstItem = Model.Items.FirstOrDefault();
     }
+
+    ThumbnailViewModel thumbnailViewModel = (ThumbnailViewModel)firstItem;
 }
 
 <div class="sf-Gallery sf-Gallery--strip">
@@ -39,7 +41,9 @@
 	<p class="sf-Gallery-image js-Gallery-image">
 		<a class='js-Gallery-prev sf-Gallery-prev'></a>
 		<a class='js-Gallery-next sf-Gallery-next'></a>
-		<img src="@(((ThumbnailViewModel)firstItem).MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" />
+        <img src="@(thumbnailViewModel.MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" 
+                  @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                  @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
 	</p>		}
 		else
 		{
@@ -64,8 +68,12 @@
 		@{int itemIndex = 0;}
 		@foreach(var item in Model.Items)
 		{
+    var itemViewModel = (ThumbnailViewModel)item;
+    
 			<a title="@item.Fields.Title" data-item="@Html.GetSerializedImage(item)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)">
-				<img src="@(((ThumbnailViewModel)item).ThumbnailUrl)"  alt="@item.Fields.AlternativeText"/>
+        <img src="@(itemViewModel.ThumbnailUrl)" alt="@item.Fields.AlternativeText" 
+                      @Html.GetWidthAttributeIfPresents(itemViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(itemViewModel.Height) />
 			</a>
 			itemIndex++;
 		}

--- a/community-packages/SemanticUI/MVC/Views/Image/Image.cshtml
+++ b/community-packages/SemanticUI/MVC/Views/Image/Image.cshtml
@@ -1,12 +1,19 @@
-@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel
-
-@if (string.IsNullOrEmpty(Model.LinkedContentUrl))
-{
-    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-}
-else
-{
-    <a href="@Model.LinkedContentUrl">
-        <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" />
-    </a>
-}
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers
+@model Telerik.Sitefinity.Frontend.Media.Mvc.Models.Image.ImageViewModel 
+ 
+@helper ImageTag() {  
+    <img class="@Model.CssClass" src="@Model.SelectedSizeUrl" title="@Model.Title" alt="@Model.AlternativeText" 
+                @Html.GetWidthAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem)
+                @Html.GetHeightAttributeForVectorGraphics(Model.CustomSize, Model.Item.DataItem) /> 
+} 
+ 
+@if (string.IsNullOrEmpty(Model.LinkedContentUrl)) 
+{ 
+    @ImageTag() 
+} 
+else 
+{ 
+    <a href="@Model.LinkedContentUrl"> 
+        @ImageTag() 
+    </a> 
+} 

--- a/community-packages/SemanticUI/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
+++ b/community-packages/SemanticUI/MVC/Views/ImageGallery/Detail.DetailPage.cshtml
@@ -1,6 +1,7 @@
 @model Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery.ImageDetailsViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Web.DataResolving;
 
@@ -18,7 +19,9 @@
 
     <p @Html.InlineEditingFieldAttributes("Description", "LongText")>@Html.Raw(Model.Item.Fields.Description)</p>
 
-	<img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+    <img src="@Html.Raw(Model.MediaUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(Model.Item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                 @Html.GetWidthAttributeIfPresents(Model.Width)
+                 @Html.GetHeightAttributeIfPresents(Model.Height) />
 
     @if (ViewBag.ItemIndex != null)
     {

--- a/community-packages/SemanticUI/MVC/Views/ImageGallery/List.ImageGallery.cshtml
+++ b/community-packages/SemanticUI/MVC/Views/ImageGallery/List.ImageGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 
@@ -13,6 +14,8 @@
     @for (int i = 0; i < Model.Items.Count(); i++)
     {
         var item = Model.Items.ElementAt(i);
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
         var itemIndex = (Model.CurrentPage - 1) * ViewBag.ItemsPerPage + i + 1;
 		var detailPageUrl = ViewBag.OpenInSamePage ? HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex) :
             HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix);
@@ -20,7 +23,9 @@
       <a
              href="@detailPageUrl"
        title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")'
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
       </a>
       }
   </div>

--- a/community-packages/SemanticUI/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
+++ b/community-packages/SemanticUI/MVC/Views/ImageGallery/List.OverlayGallery.cshtml
@@ -2,6 +2,7 @@
 
 @using Telerik.Sitefinity;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
 @using Telerik.Sitefinity.Modules.Pages;
 
@@ -17,10 +18,16 @@
     @{int itemIndex = 0;}
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
         <a class="image-link"
-            href="@(((ThumbnailViewModel)item).MediaUrl)"
+            href="@(thumbnailViewModel.MediaUrl)"
             title="@item.Fields.AlternativeText">
-            <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)" alt="@item.Fields.AlternativeText" />
+            <img src="@(thumbnailViewModel.ThumbnailUrl)" 
+                 data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)" 
+                 alt="@item.Fields.AlternativeText"
+                      @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
         </a>
         itemIndex++;
     }

--- a/community-packages/SemanticUI/MVC/Views/ImageGallery/List.SimpleList.cshtml
+++ b/community-packages/SemanticUI/MVC/Views/ImageGallery/List.SimpleList.cshtml
@@ -1,6 +1,7 @@
 @model Telerik.Sitefinity.Frontend.Mvc.Models.ContentListViewModel
 
 @using Telerik.Sitefinity;
+@using Telerik.Sitefinity.Frontend.Media.Mvc.Helpers;
 @using Telerik.Sitefinity.Frontend.Mvc.Helpers;
 @using Telerik.Sitefinity.Modules.Pages;
 @using Telerik.Sitefinity.Frontend.Media.Mvc.Models.ImageGallery;
@@ -12,8 +13,12 @@
 
     @foreach (var item in Model.Items)
     {
+        var thumbnailViewModel = (ThumbnailViewModel)item;
+        
     <a title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
-      <img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
+      <img src="@(thumbnailViewModel.ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' 
+                @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
     </a>
     }
 </div>

--- a/community-packages/SemanticUI/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
+++ b/community-packages/SemanticUI/MVC/Views/ImageGallery/List.ThumbnailStrip.cshtml
@@ -22,6 +22,8 @@
     {
         firstItem = Model.Items.FirstOrDefault();
     }
+
+    ThumbnailViewModel thumbnailViewModel = (ThumbnailViewModel)firstItem;
 }
 
 <div class="sf-Gallery sf-Gallery--strip">
@@ -39,7 +41,9 @@
 	<p class="sf-Gallery-image js-Gallery-image">
 		<a class='js-Gallery-prev sf-Gallery-prev'></a>
 		<a class='js-Gallery-next sf-Gallery-next'></a>
-		<img src="@(((ThumbnailViewModel)firstItem).MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" />
+        <img src="@(thumbnailViewModel.MediaUrl)" title="@firstItem.DataItem.Title" alt="@firstItem.DataItem.AlternativeText" 
+                  @Html.GetWidthAttributeIfPresents(thumbnailViewModel.Width)
+                  @Html.GetHeightAttributeIfPresents(thumbnailViewModel.Height) />
 	</p>
 
 		}
@@ -66,8 +70,12 @@
 		@{int itemIndex = 0;}
 		@foreach(var item in Model.Items)
 		{
+    var itemViewModel = (ThumbnailViewModel)item;
+    
 			<a title="@item.Fields.Title" data-item="@Html.GetSerializedImage(item)" data-detail-url="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, Model.UrlKeyPrefix, itemIndex)">
-				<img src="@(((ThumbnailViewModel)item).ThumbnailUrl)"  alt="@item.Fields.AlternativeText"/>
+        <img src="@(itemViewModel.ThumbnailUrl)" alt="@item.Fields.AlternativeText" 
+                      @Html.GetWidthAttributeIfPresents(itemViewModel.Width)
+                      @Html.GetHeightAttributeIfPresents(itemViewModel.Height) />
 			</a>
 			itemIndex++;
 		}


### PR DESCRIPTION
Fix for bug #211692: Feather: SVG - Image widget with Custom size is not rendered

Added fix for SVG Support in all UI Feather packages:
- [x] Default Feather UI package
- [x] SemanticUI
- [x] Minimal
- [x] Foundation
- [x] Bootstrap
